### PR TITLE
Pin an attribute of one view to another peer view.

### DIFF
--- a/UIView+AutoLayout.h
+++ b/UIView+AutoLayout.h
@@ -24,6 +24,9 @@ typedef NS_OPTIONS(unsigned long, JRTViewPinEdges){
 -(void)centerInView:(UIView*)superview;
 -(void)centerInContainerOnAxis:(NSLayoutAttribute)axis;
 
+// Pin an attribute to the same attribute on another view. EG: Set your centerX to their centerX
+-(void)pinAttribute:(NSLayoutAttribute)attribute toView:(UIView *)peerView;
+
 /// Pins a view to a specific edge(s) of its superview, with a specified inset
 -(NSArray*)pinToSuperviewEdges:(JRTViewPinEdges)edges inset:(CGFloat)inset;
 

--- a/UIView+AutoLayout.m
+++ b/UIView+AutoLayout.m
@@ -32,6 +32,16 @@
     [superview addConstraint:[NSLayoutConstraint constraintWithItem:self attribute:axis relatedBy:NSLayoutRelationEqual toItem:superview attribute:axis multiplier:1.0 constant:0.0]];
 }
 
+// Not sure how to check that an attribute is of type NSLayoutAttribute without asserting it == to every possible combination.
+-(void)pinAttribute:(NSLayoutAttribute)attribute toView:(UIView *)peerView
+{
+    NSParameterAssert(peerView);
+    UIView *superview = self.superview;
+    NSAssert(superview,@"Can't create constraints without a superview");
+    NSAssert(superview == peerView.superview,@"Can't create constraints between views that don't share a superview");
+    [superview addConstraint:[NSLayoutConstraint constraintWithItem:self attribute:attribute relatedBy:NSLayoutRelationEqual toItem:peerView attribute:attribute multiplier:1.0 constant:0.0]];
+}
+
 -(NSArray*)pinToSuperviewEdges:(JRTViewPinEdges)edges inset:(CGFloat)inset
 {
     UIView *superview = self.superview;


### PR DESCRIPTION
For instance, you can have a view constrain it's Center X to the Center X of a peer view. 
