### PR TITLE
Allow pinning edges of views that don't share the same immediate superview.

### DIFF
--- a/UIView+AutoLayout.h
+++ b/UIView+AutoLayout.h
@@ -36,6 +36,7 @@ typedef NS_OPTIONS(unsigned long, JRTViewPinEdges){
 /// Pins a view's edge to a peer view's edge
 -(void)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofView:(UIView*)peerView;
 -(void)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofView:(UIView*)peerView inset:(CGFloat)inset;
+-(void)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofView:(UIView*)peerView withSuperview:(UIView*)superview inset:(CGFloat)inset;
 
 /// Set to a specific size. 0 in any axis results in no constraint being applied.
 -(void)constrainToSize:(CGSize)size;

--- a/UIView+AutoLayout.m
+++ b/UIView+AutoLayout.m
@@ -93,10 +93,15 @@
 {
     UIView *superview = self.superview;
     NSAssert(superview,@"Can't create constraints without a superview");
-    NSAssert(superview == peerView.superview,@"Can't create constraints between views that don't share a superview");
+    NSAssert(superview == peerView.superview,@"Can't create constraints between views that don't share the same immediate superview. Use `pinEdge:toEdge:ofView:withSuperview:inset:` instead.");
     NSAssert (edge >= NSLayoutAttributeLeft && edge <= NSLayoutAttributeBottom,@"Edge parameter is not an edge");
     NSAssert (toEdge >= NSLayoutAttributeLeft && toEdge <= NSLayoutAttributeBottom,@"Edge parameter is not an edge");
     
+    [self pinEdge:edge toEdge:toEdge ofView:peerView withSuperview:superview inset:inset];
+}
+
+-(void)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofView:(UIView*)peerView withSuperview:(UIView*)superview inset:(CGFloat)inset
+{
     [superview addConstraint:[NSLayoutConstraint constraintWithItem:self attribute:edge relatedBy:NSLayoutRelationEqual toItem:peerView attribute:toEdge multiplier:1.0 constant:inset]];
 }
 


### PR DESCRIPTION
I added another variant of edge pinning: `pinEdge:toEdge:ofView:withSuperview:inset:`. This allows you to pin the edges of views, but passing in a specific superview to apply the constraints to.

`pinEdge:toEdge:ofView:inset:` now calls this new method instead, and I've also updated the `superview == peerView.superview` assert message to recommend use of the new alternative method.

Does this look okay to you?
