### PR TITLE
Restrictions on edges to centers

### DIFF
--- a/Source/UIView+AutoLayout.h
+++ b/Source/UIView+AutoLayout.h
@@ -25,8 +25,18 @@ typedef NS_OPTIONS(unsigned long, JRTViewPinEdges){
 // Pin an attribute to the same attribute on another view. Both views must be in the same view hierarchy
 -(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfView:(UIView *)peerView __deprecated;
 
+/// Pins an attribute to the any valid attribute of the peer item. The item may be the layout guide of a view controller. Provide a constant for offset/inset
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toAttribute:(NSLayoutAttribute)toAttribute ofItem:(id)peerItem withConstant:(CGFloat)constant;
+
+/// Pins an attribute to the any valid attribute of the peer item. The item may be the layout guide of a view controller
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toAttribute:(NSLayoutAttribute)toAttribute ofItem:(id)peerItem;
+
 /// Pins an attribute to the same attribute of the peer item. The item may be the layout guide of a view controller
 -(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfItem:(id)peerItem;
+
+/// Pins an attribute to the same attribute of the peer item. The item may be the layout guide of a view controller. Provide a constant for offset/inset
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfItem:(id)peerItem withConstant:(CGFloat)constant;
+
 
 /// Pins a view to a specific edge(s) of its superview, with a specified inset
 -(NSArray*)pinToSuperviewEdges:(JRTViewPinEdges)edges inset:(CGFloat)inset;

--- a/Source/UIView+AutoLayout.m
+++ b/Source/UIView+AutoLayout.m
@@ -50,9 +50,7 @@
     return constraint;
 }
 
-
--(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfItem:(id)peerItem
-{
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toAttribute:(NSLayoutAttribute)toAttribute ofItem:(id)peerItem withConstant:(CGFloat)constant {
     NSParameterAssert(peerItem);
     UIView *superview;
     if ([peerItem isKindOfClass:[UIView class]])
@@ -65,10 +63,23 @@
         superview = self.superview;
     }
     NSAssert(superview,@"Can't create constraints without a common superview");
-
-    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self attribute:attribute relatedBy:NSLayoutRelationEqual toItem:peerItem attribute:attribute multiplier:1.0 constant:0.0];
+    
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self attribute:attribute relatedBy:NSLayoutRelationEqual toItem:peerItem attribute:toAttribute multiplier:1.0 constant:constant];
     [superview addConstraint:constraint];
     return constraint;
+}
+
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toAttribute:(NSLayoutAttribute)toAttribute ofItem:(id)peerItem {
+    return [self pinAttribute:attribute toAttribute:toAttribute ofItem:peerItem withConstant:0];
+}
+
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfItem:(id)peerItem
+{
+    return [self pinAttribute:attribute toAttribute:attribute ofItem:peerItem withConstant:0];
+}
+
+-(NSLayoutConstraint *)pinAttribute:(NSLayoutAttribute)attribute toSameAttributeOfItem:(id)peerItem withConstant:(CGFloat)constant {
+    return [self pinAttribute:attribute toAttribute:attribute ofItem:peerItem withConstant:constant];
 }
 
 -(NSArray*)pinToSuperviewEdges:(JRTViewPinEdges)edges inset:(CGFloat)inset


### PR DESCRIPTION
Curious why you would restrict from pinning an edge to a center x  or y of another view? I do this all the time.

Perhaps not in the pinEdge apis, but certainly there could be a pinAttribute API for it.
