### PR TITLE
New method that allows specifying NSLayoutRelation when pinning edges

### DIFF
--- a/Source/UIView+AutoLayout.h
+++ b/Source/UIView+AutoLayout.h
@@ -55,6 +55,8 @@ typedef NS_OPTIONS(unsigned long, JRTViewPinEdges){
 -(NSLayoutConstraint *)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofItem:(id)peerItem;
 /// Pins a view's edge to a peer item's edge, with an inset. The item may be the layout guide of a view controller
 -(NSLayoutConstraint *)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofItem:(id)peerItem inset:(CGFloat)inset;
+/// Pins a view's edge to a peer item's edge, with an inset and a specific relationtype. The item may be the layout guide of a view controller.
+-(NSLayoutConstraint *)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofItem:(id)peerItem inset:(CGFloat)inset relation:(NSLayoutRelation)relation;
 
 /// Pins a views edge(s) to another views edge(s). Both views must be in the same view hierarchy.
 -(NSArray *)pinEdges:(JRTViewPinEdges)edges toSameEdgesOfView:(UIView *)peerView;

--- a/Source/UIView+AutoLayout.m
+++ b/Source/UIView+AutoLayout.m
@@ -159,6 +159,11 @@
 
 - (NSLayoutConstraint *)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofItem:(id)peerItem inset:(CGFloat)inset
 {
+    return [self pinEdge:edge toEdge:toEdge ofItem:peerItem inset:inset relation:NSLayoutRelationEqual];
+}
+
+-(NSLayoutConstraint *)pinEdge:(NSLayoutAttribute)edge toEdge:(NSLayoutAttribute)toEdge ofItem:(id)peerItem inset:(CGFloat)inset relation:(NSLayoutRelation)relation
+{
     UIView *superview;
     if ([peerItem isKindOfClass:[UIView class]])
     {
@@ -169,11 +174,11 @@
     {
         superview = self.superview;
     }
-
+    
     NSAssert (edge >= NSLayoutAttributeLeft && edge <= NSLayoutAttributeBottom,@"Edge parameter is not an edge");
     NSAssert (toEdge >= NSLayoutAttributeLeft && toEdge <= NSLayoutAttributeBottom,@"Edge parameter is not an edge");
-
-    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self attribute:edge relatedBy:NSLayoutRelationEqual toItem:peerItem attribute:toEdge multiplier:1.0 constant:inset];
+    
+    NSLayoutConstraint *constraint = [NSLayoutConstraint constraintWithItem:self attribute:edge relatedBy:relation toItem:peerItem attribute:toEdge multiplier:1.0 constant:inset];
     [superview addConstraint:constraint];
     return constraint;
 }


### PR DESCRIPTION
I'm using this functionality to solve the following example:
- I have a UIImageView constrained to 64x64 pinned to the left side of
  my UIView
- I have a UILabel (titleLabel) pinned to the right of this UIImageView
- I have a second UILabel (descriptionLabel) pinned to the right of this
  UIImageView

I want to have 10pts of margin between the main UIView's bottom edge,
and the edge of my UIImageView or descriptionLabel (whichever is
highest).

By using `NSLAyoutRelationLessThanOrEqual` I can pin both my UIImageView
_and_ my UILabel to the bottom of my parent UIView, and my UIView will
be appropriately sized.
