### PR TITLE
Fixed issue where 'centerInView:' wasn't always using the correct superview

### DIFF
--- a/AutoLayoutDemo/MainViewController.m
+++ b/AutoLayoutDemo/MainViewController.m
@@ -86,7 +86,7 @@
 
     UIView *pupil = [UIView autoLayoutView];
     pupil.backgroundColor = [UIColor blackColor];
-    [self.magentaView addSubview:pupil];
+    [self.greenView addSubview:pupil];
     [pupil constrainToSize:CGSizeMake(10.0, 10.0)];
     [pupil centerInView:self.magentaView];
 

--- a/Source/UIView+AutoLayout.h
+++ b/Source/UIView+AutoLayout.h
@@ -18,8 +18,10 @@ typedef NS_OPTIONS(unsigned long, JRTViewPinEdges){
 /// Return a frameless view that does not automatically use autoresizing (for use in autolayouts)
 +(instancetype)autoLayoutView;
 
+/// Centers the receiver in the specified view
+-(NSArray *)centerInView:(UIView*)view;
+
 /// Centers the receiver in the superview
--(NSArray *)centerInView:(UIView*)superview;
 -(NSLayoutConstraint *)centerInContainerOnAxis:(NSLayoutAttribute)axis;
 
 // Pin an attribute to the same attribute on another view. Both views must be in the same view hierarchy

--- a/Source/UIView+AutoLayout.m
+++ b/Source/UIView+AutoLayout.m
@@ -17,14 +17,17 @@
     return viewToReturn;
 }
 
--(NSArray *)centerInView:(UIView*)superview
+-(NSArray *)centerInView:(UIView*)view
 {
     NSMutableArray *constraints = [NSMutableArray new];
 
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0]];
-    [constraints addObject:[NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:superview attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0]];
+    [constraints addObject:[NSLayoutConstraint constraintWithItem:self attribute:NSLayoutAttributeCenterY relatedBy:NSLayoutRelationEqual toItem:view attribute:NSLayoutAttributeCenterY multiplier:1.0 constant:0]];
+
+    UIView *superview = [self commonSuperviewWithView:view];
 
     [superview addConstraints:constraints];
+
     return [constraints copy];
 }
 


### PR DESCRIPTION
the `centerInView:` method wasn't using the appropriate superview if you added the receiver higher in the view hierarchy than the view you wanted to centre it in was.

The demo view also reflects this scenario now with the pupil view.
