### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The demo project is most of the way towards drawing a robot made of views arrang
 Installation
 -------------
 
-**Using [Cocoapods](http://cocoapods.org/):**
+**Using [CocoaPods](http://cocoapods.org/):**
 
 `pod 'UIView-Autolayout', '~> 0.2.0'`
 
@@ -36,8 +36,8 @@ Deprecated Methods
 As of version 1.0.0, all deprecated methods will be removed from this category.
 All deprecated methods are marked with a compiler flag providing instructions on alternative methods to use but for more information check out the API documentation on the Cocoadocs website listed above.
 
-If you are using Cocoapods and do not wish to upgrade to version 1.0.0 then you can specify the following in your Podfile:
+If you are using CocoaPods and do not wish to upgrade to version 1.0.0 then you can specify the following in your Podfile:
 
 `pod 'UIView-Autolayout', '~> 0.2.0'`
 
-This will prevent Cocoapods installing any 1.0.0 updates.
+This will prevent CocoaPods installing any 1.0.0 updates.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
